### PR TITLE
Redraw all lines on map view restart

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "de.timklge.karootilehunting"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "1.0-beta5"
+        versionCode = 6
+        versionName = "1.0-beta6"
     }
 
     signingConfigs {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,9 +3,9 @@
   "packageName": "de.timklge.karootilehunting",
   "iconUrl": "https://github.com/timklge/karoo-tilehunting/releases/latest/download/karoo-tilehunting.png",
   "latestApkUrl": "https://github.com/timklge/karoo-tilehunting/releases/latest/download/app-release.apk",
-  "latestVersion": "1.0-beta5",
-  "latestVersionCode": 5,
+  "latestVersion": "1.0-beta6",
+  "latestVersionCode": 6,
   "developer": "timklge",
   "description": "Tilehunting extension for the karoo. Downloads tiles from statshunters.com and displays tile outlines and past activities on the map.",
-  "releaseNotes": "Initial release"
+  "releaseNotes": "Optimize drawing"
 }

--- a/app/src/main/kotlin/de/timklge/karootilehunting/KarooTilehuntingExtension.kt
+++ b/app/src/main/kotlin/de/timklge/karootilehunting/KarooTilehuntingExtension.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
-class KarooTilehuntingExtension : KarooExtension("karoo-tilehunting", "1.0-beta5") {
+class KarooTilehuntingExtension : KarooExtension("karoo-tilehunting", "1.0-beta6") {
     companion object {
         const val TAG = "karoo-tilehunting"
     }

--- a/app/src/main/kotlin/de/timklge/karootilehunting/services/ClusterDrawService.kt
+++ b/app/src/main/kotlin/de/timklge/karootilehunting/services/ClusterDrawService.kt
@@ -59,6 +59,9 @@ class ClusterDrawService(private val karooSystem: KarooSystemServiceProvider,
 
     fun startJob(emitter: Emitter<MapEffect>): Job {
         val tileClusterJob = CoroutineScope(Dispatchers.IO).launch {
+            // First, redrawa everything that should already be drawn
+            lastDrawnPolylines.forEach { emitter.onNext(it) }
+
             val mapZoomFlow = karooSystem.stream<OnMapZoomLevel>().map { (it.zoomLevel / 2).roundToInt() * 2 }
 
             val gpsTileFlow = gpsFlow.map { coordsToTile(it.latitude, it.longitude) }.throttle(10_000L)


### PR DESCRIPTION
Fixes issues with missing lines if the map view is restarted while the extension is running (e. g. by changing profiles)